### PR TITLE
Fix compile on FreeBSD

### DIFF
--- a/include/dmx.h
+++ b/include/dmx.h
@@ -24,7 +24,7 @@
 #ifndef _DVBDMX_H_
 #define _DVBDMX_H_
 
-#include <linux/types.h>
+#include "linuxtypes.h"
 #include <time.h>
 
 

--- a/include/frontend.h
+++ b/include/frontend.h
@@ -26,7 +26,7 @@
 #ifndef _DVBFRONTEND_H_
 #define _DVBFRONTEND_H_
 
-#include <linux/types.h>
+#include "linuxtypes.h"
 
 typedef enum fe_type {
 	FE_QPSK,

--- a/include/linuxtypes.h
+++ b/include/linuxtypes.h
@@ -1,0 +1,13 @@
+#ifdef __linux__
+#include <linux/types.h>
+#else
+#ifndef LINUX_TYPES_ADDED
+#define LINUX_TYPES_ADDED
+#include <sys/types.h>
+typedef uint64_t __u64;
+typedef uint32_t __u32;
+typedef uint16_t __u16;
+typedef uint8_t __u8;
+typedef int64_t __s64;
+#endif
+#endif

--- a/src/dvb/dvbdevice_linux.cpp
+++ b/src/dvb/dvbdevice_linux.cpp
@@ -35,7 +35,9 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#ifdef __linux__
 #include <sys/inotify.h>
+#endif
 #include <vector>
 #include <stdlib.h>
 #include <unistd.h>
@@ -853,9 +855,10 @@ public:
                 std::vector<struct dvbdev*>::iterator iter;
 
                 runstate = 1;
-
+#ifdef __linux__
                 ifd = inotify_init();
                 inotify_add_watch(ifd, "/dev/dvb", IN_CREATE|IN_DELETE);
+#endif
                 fcntl(ifd, F_SETFL, O_NONBLOCK);
                 pfd.fd = ifd;
                 pfd.events = POLLIN;


### PR DESCRIPTION
Kaffeine uses some non-portable types from linux/types.h. Provide some typedefs in case linux/types.h does not exist.

inotify does not exist on non-linux. hide it behind ifdefs
