### PR TITLE
Add support for parallel instant records

### DIFF
--- a/src/dvb/dvbtab.h
+++ b/src/dvb/dvbtab.h
@@ -23,6 +23,8 @@
 
 #include <QPointer>
 #include <QTimer>
+#include <QList>
+#include <QIcon>
 #include <config-kaffeine.h>
 #include "../tabbase.h"
 #include "../mediawidget.h"
@@ -81,10 +83,12 @@ private slots:
 private:
 	void activate();
 	void playChannel(const DvbSharedChannel &channel, const QModelIndex &index);
+	DvbSharedRecording *getInstantRecording(DvbSharedChannel ch);
 
 	MediaWidget *mediaWidget;
 	DvbManager *manager;
 	QAction *instantRecordAction;
+	QList<DvbSharedRecording> instantRecordings;
 	DvbSharedRecording instantRecording;
 	QSplitter *splitter;
 	QWidget *leftWidget;
@@ -96,6 +100,8 @@ private:
 	QTimer osdChannelTimer;
 	QString currentChannel;
 	QString lastChannel;
+	QIcon mediaRecordIcon;
+	QIcon documentSaveIcon;
 	bool autoHideMenu;
 	QTimer *cursorHideTimer;
 


### PR DESCRIPTION
- This allows to record multiple channels from an identical transponder
  (e. g. DVB-S) at the same time using the instant record button/menu
- Therefore the instant record button/menu has an individual state for each
  channel (it changes by switching the channel). This behavior
  is used by the old kaffeine 0.8 for KDE3, too.
- Without this patch, parallel records are possible using the record scheduler
  (e. g. via EPG menu)

Signed-off-by: Stefan Koch <stefan.koch10@gmail.com>