### PR TITLE
Fix audio CD playing

### DIFF
--- a/src/backend-vlc/vlcmediawidget.h
+++ b/src/backend-vlc/vlcmediawidget.h
@@ -25,6 +25,7 @@
 
 class libvlc_event_t;
 class libvlc_instance_t;
+class libvlc_media_t;
 class libvlc_media_player_t;
 class QTimer;
 
@@ -68,6 +69,8 @@ public:
 	bool jumpToNextChapter();
 	void showDvdMenu();
 	void dvdNavigate(int key);
+	void playDirection(int direction);
+	void makePlay();
 
 	int updatePlaybackStatus();
 	void updateCurrentTotalTime();
@@ -90,10 +93,14 @@ private:
 	static void vlcEventHandler(const libvlc_event_t *event, void *instance);
 
 	libvlc_instance_t *vlcInstance;
+	libvlc_media_t *vlcMedia;
 	libvlc_media_player_t *vlcMediaPlayer;
 	bool playingDvd;
 	bool mouseVisible;
 	QMap<int, int> subtitleId;
+    QByteArray typeOfDevice;
+    int numDevType;
+    int trackNumber = 1;
 };
 
 #endif /* VLCMEDIAWIDGET_H */

--- a/src/mediawidget.cpp
+++ b/src/mediawidget.cpp
@@ -793,14 +793,14 @@ void MediaWidget::previous()
 {
 	if (source->getType() == MediaSource::Url)
 		emit playlistPrevious();
-	source->previous();
+	backend->jumpToPreviousChapter();
 }
 
 void MediaWidget::next()
 {
 	if (source->getType() == MediaSource::Url)
 		emit playlistNext();
-	source->next();
+	backend->jumpToNextChapter();
 }
 
 void MediaWidget::stop()


### PR DESCRIPTION
With the new version of vlc, audio cd playback broke, this PR corrects the problem.
    - all tracks playing
    - 'next' & 'previous' working

https://forum.kde.org/viewtopic.php?f=19&t=154030&p=404026&hilit=kaffeine#p404026