### PR TITLE
With TBS Tuner cards, Kaffeine Player hangs while switching channels.…

### DIFF
--- a/src/dvb/dvbliveview.cpp
+++ b/src/dvb/dvbliveview.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "../log.h"
-
+#include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <KMessageBox>
@@ -250,6 +250,8 @@ void DvbLiveView::playChannel(const DvbSharedChannel &channel_)
 	}
 
 	playbackStatusChanged(MediaWidget::Idle);
+	// 1 second delay to release dvb tuner from previous playback
+	usleep(1000000);
 	channel = channel_;
 	device = newDevice;
 


### PR DESCRIPTION
… It tries to access the tuner while the previous channel is tuned.  This problem is solved by adding 1 second delay between "Setting the player Idle" and "playing the next channel"